### PR TITLE
fix: allow socket transport fallback

### DIFF
--- a/quoridor-client/src/contexts/SocketContext.tsx
+++ b/quoridor-client/src/contexts/SocketContext.tsx
@@ -62,7 +62,8 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
     const newSocket = socket || io(wsUrl, {
       auth: { token },
       autoConnect: false, // 수동으로 connect() 호출
-      transports: ['websocket'], // WebSocket-only
+      // Allow polling fallback in addition to WebSocket for more robust connections
+      transports: ['websocket', 'polling'],
       reconnection: true,
       reconnectionAttempts: 5,
       reconnectionDelay: 3000,

--- a/quoridor-server/src/server.ts
+++ b/quoridor-server/src/server.ts
@@ -26,7 +26,8 @@ const io = new Server(httpServer, {
         credentials: true,
         allowedHeaders: ["Content-Type", "Authorization", "Origin"]
     },
-    transports: ['websocket'] // WebSocket-only
+    // Allow fallback to HTTP long-polling to reduce connection errors
+    transports: ['websocket', 'polling']
 });
 
 app.use(cors({


### PR DESCRIPTION
## Summary
- allow HTTP long-polling fallback for socket.io connections on server
- enable client to use polling as fallback to reduce frequent connection errors

## Testing
- `npm run build` *(fails: src/game/GameManager.ts: Expected 4 arguments, got 5)*
- `CI=true npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68a47cc3a0148322ac64c72a47b87cbe