### PR TITLE
chore: fix import order in types

### DIFF
--- a/quoridor-server/src/types.ts
+++ b/quoridor-server/src/types.ts
@@ -1,9 +1,10 @@
+import { Socket } from 'socket.io';
+
 export interface ExtendedSocket extends Socket {
     userId?: string;
     rating?: number;
     username?: string;
 }
-import { Socket } from 'socket.io';
 
 export interface Position {
     row: number;


### PR DESCRIPTION
## Summary
- move Socket import to top of `types.ts`

## Testing
- `npm --prefix quoridor-server run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab117d94048322944fe6f8ddf274ae