### PR TITLE
fix: handle move event payload and sync initial state

### DIFF
--- a/quoridor-client/src/components/pages/hooks/useGameSocket.ts
+++ b/quoridor-client/src/components/pages/hooks/useGameSocket.ts
@@ -43,12 +43,10 @@ export function useGameSocket({
     });
 
     socket.on('gameStarted', (data: GameStartData) => {
-      if (!playerId || !setPlayerInfo) {
-        setPlayerId(data.playerId);
-        setGameState(data.gameState);
-        setPlayerInfo(data.playerInfo);
-        resetTimer();
-      }
+      setPlayerId(data.playerId);
+      setGameState(data.gameState);
+      setPlayerInfo(data.playerInfo);
+      resetTimer();
     });
 
     socket.on('gameStateUpdate', (newGameState: GameState) => {

--- a/quoridor-server/src/game/handlers/GameHandler.ts
+++ b/quoridor-server/src/game/handlers/GameHandler.ts
@@ -120,7 +120,7 @@ export class GameHandler {
     console.log(`🎯 현재 활성 방 수: ${this.rooms.size}`);
   }
 
-  handlePlayerMove(socket: Socket, data: { position: ServerPosition }) {
+  handlePlayerMove(socket: Socket, data: { position?: ServerPosition; to?: ServerPosition }) {
     const room = findPlayerRoom(socket.id, this.rooms);
     if (!room || !room.isGameActive) {
       socket.emit('error', '활성화된 게임을 찾을 수 없습니다.');
@@ -138,14 +138,20 @@ export class GameHandler {
       return;
     }
 
+    const targetPosition = data.position || data.to;
+    if (!targetPosition) {
+      socket.emit('error', '이동할 위치가 제공되지 않았습니다.');
+      return;
+    }
+
     console.log(`🎯 플레이어 이동 시도:`, {
       player: playerData.playerId,
       from: room.gameState[playerData.playerId].position,
-      to: data.position
+      to: targetPosition
     });
 
     try {
-      const newGameState = GameLogic.makeMove(room.gameState, data.position);
+      const newGameState = GameLogic.makeMove(room.gameState, targetPosition);
       room.gameState = newGameState;
 
       this.io.to(room.id).emit('gameStateUpdate', newGameState);


### PR DESCRIPTION
## Summary
- allow move handler to read `to` field sent by client
- validate move payload and log more details
- always set initial game state on game start

## Testing
- `cd quoridor-client && pnpm build`
- `cd quoridor-server && pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ab1480fcb483229b4899b9263beacf