### PR TITLE
fix: handle move event payload and sync initial state

### DIFF
--- a/quoridor-client/src/components/pages/hooks/useGameSocket.ts
+++ b/quoridor-client/src/components/pages/hooks/useGameSocket.ts
@@ -43,12 +43,10 @@ export function useGameSocket({
     });
 
     socket.on('gameStarted', (data: GameStartData) => {
-      if (!playerId || !setPlayerInfo) {
-        setPlayerId(data.playerId);
-        setGameState(data.gameState);
-        setPlayerInfo(data.playerInfo);
-        resetTimer();
-      }
+      setPlayerId(data.playerId);
+      setGameState(data.gameState);
+      setPlayerInfo(data.playerInfo);
+      resetTimer();
     });
 
     socket.on('gameStateUpdate', (newGameState: GameState) => {

--- a/quoridor-client/src/contexts/SocketContext.tsx
+++ b/quoridor-client/src/contexts/SocketContext.tsx
@@ -59,11 +59,11 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
       hasToken: !!token,
       hasSocket: !!socket,
       socketConnected: socket?.connected,
-      wsUrl: process.env.REACT_APP_WS_URL || 'ws://localhost:4000'
+      wsUrl: process.env.REACT_APP_WS_URL || 'http://localhost:4000'
     });
     // 기존 소켓이 있다면 재사용, 없다면 새로 생성
     console.log(socket ? '♻️ 기존 소켓 재사용...' : '✨ 새 소켓 생성...');
-    const wsUrl = process.env.REACT_APP_WS_URL || 'wss://quoridoronline-5ngr.onrender.com';
+    const wsUrl = process.env.REACT_APP_WS_URL || 'https://quoridoronline-5ngr.onrender.com';
     const newSocket = socket || io(wsUrl, {
       auth: { token },
       autoConnect: false, // 수동으로 connect() 호출

--- a/quoridor-server/src/game/handlers/GameHandler.ts
+++ b/quoridor-server/src/game/handlers/GameHandler.ts
@@ -120,7 +120,7 @@ export class GameHandler {
     console.log(`🎯 현재 활성 방 수: ${this.rooms.size}`);
   }
 
-  handlePlayerMove(socket: Socket, data: { position: ServerPosition }) {
+  handlePlayerMove(socket: Socket, data: { position?: ServerPosition; to?: ServerPosition }) {
     const room = findPlayerRoom(socket.id, this.rooms);
     if (!room || !room.isGameActive) {
       socket.emit('error', '활성화된 게임을 찾을 수 없습니다.');
@@ -138,14 +138,20 @@ export class GameHandler {
       return;
     }
 
+    const targetPosition = data.position || data.to;
+    if (!targetPosition) {
+      socket.emit('error', '이동할 위치가 제공되지 않았습니다.');
+      return;
+    }
+
     console.log(`🎯 플레이어 이동 시도:`, {
       player: playerData.playerId,
       from: room.gameState[playerData.playerId].position,
-      to: data.position
+      to: targetPosition
     });
 
     try {
-      const newGameState = GameLogic.makeMove(room.gameState, data.position);
+      const newGameState = GameLogic.makeMove(room.gameState, targetPosition);
       room.gameState = newGameState;
 
       this.io.to(room.id).emit('gameStateUpdate', newGameState);

--- a/quoridor-server/src/server.ts
+++ b/quoridor-server/src/server.ts
@@ -33,6 +33,8 @@ const io = new Server(httpServer, {
     pingInterval: 25000
 });
 
+// 게임 매니저 초기화는 라우트보다 먼저 수행해 공용 API에서 통계 접근 가능하도록 함
+const gameManager = new GameManager(io);
 
 app.use(cors({
     origin: config.allowedOrigins,
@@ -62,14 +64,7 @@ app.get('/', (req, res) => {
     });
 });
 
-// 라우트 설정
-app.use('/api', authRoutes);
-app.use('/api', gameRoutes);
-
-// 게임 매니저 초기화
-const gameManager = new GameManager(io);
-
-// 공지 및 통계 API
+// 공지 및 통계 API는 다른 라우터보다 먼저 설정하여 404를 방지
 app.get('/api/notice', (_req, res) => {
     res.json([
         { id: '1', message: '퀘도르 온라인에 오신 것을 환영합니다!', type: 'event' }
@@ -79,6 +74,10 @@ app.get('/api/notice', (_req, res) => {
 app.get('/api/stats', (_req, res) => {
     res.json(gameManager.getStats());
 });
+
+// 라우트 설정
+app.use('/api', authRoutes);
+app.use('/api', gameRoutes);
 
 // 서버 시작
 const PORT = config.port;


### PR DESCRIPTION
## Summary
- allow move handler to read `to` field sent by client
- validate move payload and log more details
- always set initial game state on game start
- initialize GameManager before routes and expose `/api/notice` and `/api/stats`
- use HTTPS base for socket connection to avoid timeouts

## Testing
- `cd quoridor-client && pnpm build`
- `cd quoridor-server && pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ab1480fcb483229b4899b9263beacf