### PR TITLE
feat: restyle board and align wall preview

### DIFF
--- a/quoridor-client/src/components/Board.tsx
+++ b/quoridor-client/src/components/Board.tsx
@@ -48,8 +48,8 @@ const BoardContainer = styled.div`
   }
 `;
 
-const Cell = styled.div<{ isMyTurn: boolean; isValidMove: boolean; isDark: boolean }>`
-  background-color: ${props => props.isValidMove ? '#f6f669' : (props.isDark ? 'var(--color-dark)' : 'var(--color-light)')};
+const Cell = styled.div<{ isMyTurn: boolean; isValidMove: boolean }>`
+  background-color: ${props => props.isValidMove ? '#f6f669' : 'var(--color-light)'};
   width: 100%;
   height: 100%;
   display: flex;
@@ -62,7 +62,7 @@ const Cell = styled.div<{ isMyTurn: boolean; isValidMove: boolean; isDark: boole
   box-shadow: none;
 
   &:hover {
-    background-color: ${props => props.isMyTurn && props.isValidMove ? '#f6f669' : (props.isMyTurn ? (props.isDark ? '#c0a07a' : '#fff') : '')};
+    background-color: ${props => props.isMyTurn ? (props.isValidMove ? '#f6f669' : '#fff') : ''};
     transform: ${props => props.isMyTurn ? 'translateY(-1px)' : 'none'};
   }
 `;
@@ -92,12 +92,10 @@ const Wall = styled.div<{ orientation: 'horizontal' | 'vertical'; color: string 
       ? `
         height: var(--gap);
         width: calc(2 * var(--cell-size) + var(--gap));
-        transform: translateY(-50%);
       `
       : `
         width: var(--gap);
         height: calc(2 * var(--cell-size) + var(--gap));
-        transform: translateX(-50%);
       `}
 `;
 
@@ -110,12 +108,10 @@ const WallPlacementArea = styled.div<{ orientation: 'horizontal' | 'vertical'; i
       ? `
         height: var(--gap);
         width: calc(2 * var(--cell-size) + var(--gap));
-        transform: translateY(-50%);
       `
       : `
         width: var(--gap);
         height: calc(2 * var(--cell-size) + var(--gap));
-        transform: translateX(-50%);
       `}
 
   &:hover {
@@ -175,7 +171,6 @@ const Board: React.FC<BoardProps> = ({ gameState, onCellClick, onWallPlace, play
         key={`${x}-${y}`}
         isMyTurn={isMyTurn}
         isValidMove={isValidMove}
-        isDark={(x + y) % 2 === 1}
         onClick={() => handleCellClick(x, y)}
       >
         {playerOnCell && (
@@ -194,13 +189,13 @@ const Board: React.FC<BoardProps> = ({ gameState, onCellClick, onWallPlace, play
 
     if (wall.orientation === 'horizontal') {
       return {
-        top: `calc(${topOffset} + var(--cell-size) + var(--gap) / 2)`,
+        top: `calc(${topOffset} + var(--cell-size))`,
         left: leftOffset,
       };
-    } else { // vertical
+    } else {
       return {
         top: topOffset,
-        left: `calc(${leftOffset} + var(--cell-size) + var(--gap) / 2)`,
+        left: `calc(${leftOffset} + var(--cell-size))`,
       };
     }
   };

--- a/quoridor-client/src/components/pages/hooks/useGameSocket.ts
+++ b/quoridor-client/src/components/pages/hooks/useGameSocket.ts
@@ -43,12 +43,10 @@ export function useGameSocket({
     });
 
     socket.on('gameStarted', (data: GameStartData) => {
-      if (!playerId || !setPlayerInfo) {
-        setPlayerId(data.playerId);
-        setGameState(data.gameState);
-        setPlayerInfo(data.playerInfo);
-        resetTimer();
-      }
+      setPlayerId(data.playerId);
+      setGameState(data.gameState);
+      setPlayerInfo(data.playerInfo);
+      resetTimer();
     });
 
     socket.on('gameStateUpdate', (newGameState: GameState) => {

--- a/quoridor-client/src/contexts/SocketContext.tsx
+++ b/quoridor-client/src/contexts/SocketContext.tsx
@@ -59,22 +59,26 @@ export const SocketProvider: React.FC<SocketProviderProps> = ({ children }) => {
       hasToken: !!token,
       hasSocket: !!socket,
       socketConnected: socket?.connected,
-      wsUrl: process.env.REACT_APP_WS_URL || 'ws://localhost:4000'
+      wsUrl: process.env.REACT_APP_WS_URL || 'http://localhost:4000'
     });
     // 기존 소켓이 있다면 재사용, 없다면 새로 생성
     console.log(socket ? '♻️ 기존 소켓 재사용...' : '✨ 새 소켓 생성...');
-    const wsUrl = process.env.REACT_APP_WS_URL || 'wss://quoridoronline-5ngr.onrender.com';
-    const newSocket = socket || io(wsUrl, {
-      auth: { token },
-      autoConnect: false, // 수동으로 connect() 호출
-      // Allow polling fallback in addition to WebSocket for more robust connections
-      transports: ['polling', 'websocket'],
-      reconnection: true,
-      reconnectionAttempts: Infinity,
-      reconnectionDelay: 1000,
-      reconnectionDelayMax: 5000,
-      timeout: 10000
-    });
+    const wsUrl = process.env.REACT_APP_WS_URL || 'https://quoridoronline-5ngr.onrender.com';
+    const newSocket =
+      socket ||
+      io(wsUrl, {
+        auth: { token },
+        autoConnect: false, // 수동으로 connect() 호출
+        // 인증 토큰 전달과 함께 CORS 자격 증명 사용
+        withCredentials: true,
+        // Use WebSocket transport only to avoid CORS issues with polling
+        transports: ['websocket'],
+        reconnection: true,
+        reconnectionAttempts: Infinity,
+        reconnectionDelay: 1000,
+        reconnectionDelayMax: 5000,
+        timeout: 10000
+      } as any);
     console.log('🚀 소켓 연결 실행...');
     connectingRef.current = true;
     if (!newSocket.connected) {

--- a/quoridor-server/src/game/handlers/GameHandler.ts
+++ b/quoridor-server/src/game/handlers/GameHandler.ts
@@ -120,7 +120,7 @@ export class GameHandler {
     console.log(`🎯 현재 활성 방 수: ${this.rooms.size}`);
   }
 
-  handlePlayerMove(socket: Socket, data: { position: ServerPosition }) {
+  handlePlayerMove(socket: Socket, data: { position?: ServerPosition; to?: ServerPosition }) {
     const room = findPlayerRoom(socket.id, this.rooms);
     if (!room || !room.isGameActive) {
       socket.emit('error', '활성화된 게임을 찾을 수 없습니다.');
@@ -138,14 +138,20 @@ export class GameHandler {
       return;
     }
 
+    const targetPosition = data.position || data.to;
+    if (!targetPosition) {
+      socket.emit('error', '이동할 위치가 제공되지 않았습니다.');
+      return;
+    }
+
     console.log(`🎯 플레이어 이동 시도:`, {
       player: playerData.playerId,
       from: room.gameState[playerData.playerId].position,
-      to: data.position
+      to: targetPosition
     });
 
     try {
-      const newGameState = GameLogic.makeMove(room.gameState, data.position);
+      const newGameState = GameLogic.makeMove(room.gameState, targetPosition);
       room.gameState = newGameState;
 
       this.io.to(room.id).emit('gameStateUpdate', newGameState);

--- a/quoridor-server/src/server.ts
+++ b/quoridor-server/src/server.ts
@@ -19,27 +19,44 @@ const httpServer = createServer(app);
 
 console.log('Allowed CORS origins:', config.allowedOrigins);
 
-const io = new Server(httpServer, {
-    cors: {
-        origin: config.allowedOrigins,
-        methods: ["GET", "POST"],
-        credentials: true,
-        allowedHeaders: ["Content-Type", "Authorization", "Origin"]
+// check if the request origin matches one of the allowed origins.
+// supports wildcard entries like `deploy-preview-*.netlify.app`
+const isOriginAllowed = (origin: string) => {
+    return config.allowedOrigins.some((allowed) => {
+        if (allowed.includes('*')) {
+            const pattern = new RegExp('^' + allowed.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
+            return pattern.test(origin);
+        }
+        return allowed === origin;
+    });
+};
+
+const corsOptions = {
+    origin: (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) => {
+        if (!origin || isOriginAllowed(origin)) {
+            callback(null, true);
+        } else {
+            console.log('Blocked CORS origin:', origin);
+            callback(null, false);
+        }
     },
-    // Allow fallback to HTTP long-polling to reduce connection errors
-    // Start with polling so the connection succeeds even if WebSocket is blocked
-    transports: ['polling', 'websocket'],
+    credentials: true,
+    methods: ["GET", "POST"]
+};
+
+const io = new Server(httpServer, {
+    cors: corsOptions,
+    // Use WebSocket transport exclusively to avoid polling CORS issues
+    transports: ['websocket'],
     pingTimeout: 20000,
     pingInterval: 25000
 });
 
+// 게임 매니저 초기화는 라우트보다 먼저 수행해 공용 API에서 통계 접근 가능하도록 함
+const gameManager = new GameManager(io);
 
-app.use(cors({
-    origin: config.allowedOrigins,
-    credentials: true,
-    methods: ["GET", "POST"],
-    allowedHeaders: ["Content-Type", "Authorization", "Origin"]
-}));
+app.use(cors(corsOptions));
+app.options('*', cors(corsOptions));
 app.use(express.json());
 
 // 요청 로깅 미들웨어
@@ -62,14 +79,7 @@ app.get('/', (req, res) => {
     });
 });
 
-// 라우트 설정
-app.use('/api', authRoutes);
-app.use('/api', gameRoutes);
-
-// 게임 매니저 초기화
-const gameManager = new GameManager(io);
-
-// 공지 및 통계 API
+// 공지 및 통계 API는 다른 라우터보다 먼저 설정하여 404를 방지
 app.get('/api/notice', (_req, res) => {
     res.json([
         { id: '1', message: '퀘도르 온라인에 오신 것을 환영합니다!', type: 'event' }
@@ -79,6 +89,10 @@ app.get('/api/notice', (_req, res) => {
 app.get('/api/stats', (_req, res) => {
     res.json(gameManager.getStats());
 });
+
+// 라우트 설정
+app.use('/api', authRoutes);
+app.use('/api', gameRoutes);
 
 // 서버 시작
 const PORT = config.port;


### PR DESCRIPTION
## Summary
- allow move handler to read `to` field sent by client
- validate move payload and log more details
- always set initial game state on game start
- initialize GameManager before routes and expose `/api/notice` and `/api/stats`
- use HTTPS base for socket connection to avoid timeouts
- restyle board with single-color cells and dark gaps
- align wall placement areas and preview for precise placement
- broaden CORS config and enable credentials for socket.io so game clients can connect across domains
- tolerate unknown origins without throwing so CORS errors do not surface as 503 responses
- enforce WebSocket transport on client and server to eliminate polling CORS errors

## Testing
- `cd quoridor-server && pnpm build`
- `cd quoridor-client && pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ab1480fcb483229b4899b9263beacf